### PR TITLE
made download field unsortable

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,7 +36,7 @@
             <th data-field="extension" data-sortable="true"><i class="fa fa-file"></i> Extension</th>
             <th data-field="software" data-sortable="true"><i class="fa fa-star"></i> Software</th>
             <th data-field="mime" data-sortable="true" data-visible="false"><i class="fa fa-info-circle"></i> MIME-Type</th>
-            <th data-field="download" data-sortable="true" data-formatter="operateFormatter"><i class="fa fa-cloud-download"></i> Download</th>
+            <th data-field="download" data-sortable="false" data-formatter="operateFormatter"><i class="fa fa-cloud-download"></i> Download</th>
           </tr>
         </thead>
       </table>


### PR DESCRIPTION
The Download field has no reason to be sortable since it's the same in every row.

I have no idea why Github added and removed some random lines